### PR TITLE
fix import path golang.org/x/crypt & format with "go fmt"

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -251,7 +251,9 @@ func (a Authorizer) Authorize(rw http.ResponseWriter, req *http.Request) (*UserD
 		user, err := a.backend.User(name)
 		if err == ErrMissingUser {
 			session.Options.MaxAge = -1 // kill the cookie
-			session.Save(req, rw)
+			if rw != nil {
+				session.Save(req, rw)
+			}
 			return nil, mkerror("user not found")
 		} else if err != nil {
 			return nil, mkerror(err.Error())

--- a/auth.go
+++ b/auth.go
@@ -43,10 +43,10 @@ type Role int
 // users, you should not specify a hash; it will be generated in the Register
 // and Update functions.
 type UserData struct {
-	Username string `bson:"Username"`
-	Email    string `bson:"Email"`
-	Hash     []byte `bson:"Hash"`
-	Role     string `bson:"Role"`
+	Name  string `bson:"Name"`
+	Email string `bson:"Email"`
+	Hash  []byte `bson:"Hash"`
+	Role  string `bson:"Role"`
 }
 
 // Authorizer structures contain the store of user session cookies a reference
@@ -73,15 +73,6 @@ func (a Authorizer) addMessage(rw http.ResponseWriter, req *http.Request, messag
 	messageSession, _ := a.cookiejar.Get(req, "messages")
 	defer messageSession.Save(req, rw)
 	messageSession.AddFlash(message)
-}
-
-// Helper function to save a redirect to the page a user tried to visit before
-// logging in.
-func (a Authorizer) goBack(rw http.ResponseWriter, req *http.Request) {
-	redirectSession, _ := a.cookiejar.Get(req, "redirects")
-	defer redirectSession.Save(req, rw)
-	redirectSession.Flashes()
-	redirectSession.AddFlash(req.URL.Path)
 }
 
 func mkerror(msg string) error {
@@ -148,11 +139,8 @@ func (a Authorizer) Login(rw http.ResponseWriter, req *http.Request, u string, p
 // Pass in a instance of UserData with at least a username and email specified. If no role
 // is given, the default one is used.
 func (a Authorizer) Register(rw http.ResponseWriter, req *http.Request, user UserData, password string) error {
-	if user.Username == "" {
+	if user.Name == "" {
 		return mkerror("no username given")
-	}
-	if user.Email == "" {
-		return mkerror("no email given")
 	}
 	if user.Hash != nil {
 		return mkerror("hash will be overwritten")
@@ -162,9 +150,9 @@ func (a Authorizer) Register(rw http.ResponseWriter, req *http.Request, user Use
 	}
 
 	// Validate username
-	_, err := a.backend.User(user.Username)
+	_, err := a.backend.User(user.Name)
 	if err == nil {
-		a.addMessage(rw, req, "Username has been taken.")
+		a.addMessage(rw, req, "Name has been taken.")
 		return mkerror("user already exists")
 	} else if err != ErrMissingUser {
 		if err != nil {
@@ -174,7 +162,7 @@ func (a Authorizer) Register(rw http.ResponseWriter, req *http.Request, user Use
 	}
 
 	// Generate and save hash
-	hash, err := bcrypt.GenerateFromPassword([]byte(user.Username+password), 8)
+	hash, err := bcrypt.GenerateFromPassword([]byte(user.Name+password), 8)
 	if err != nil {
 		return mkerror("couldn't save password: " + err.Error())
 	}
@@ -203,8 +191,8 @@ func (a Authorizer) Update(rw http.ResponseWriter, req *http.Request, p string, 
 		hash  []byte
 		email string
 	)
-	authSession, err := a.cookiejar.Get(req, "auth")
-	username, ok := authSession.Values["username"].(string)
+	session, err := a.cookiejar.Get(req, "auth")
+	username, ok := session.Values["username"].(string)
 	if !ok {
 		return mkerror("not logged in")
 	}
@@ -238,86 +226,49 @@ func (a Authorizer) Update(rw http.ResponseWriter, req *http.Request, p string, 
 	return nil
 }
 
+// ChangeRole changes the role for an existing user.
+func (a Authorizer) ChangeRole(user *UserData, role string) error {
+	var u UserData = *user
+	u.Role = role
+	return a.backend.SaveUser(u)
+}
+
 // Authorize checks if a user is logged in and returns an error on failed
 // authentication. If redirectWithMessage is set, the page being authorized
 // will be saved and a "Login to do that." message will be saved to the
 // messages list. The next time the user logs in, they will be redirected back
 // to the saved page.
-func (a Authorizer) Authorize(rw http.ResponseWriter, req *http.Request, redirectWithMessage bool) error {
-	authSession, err := a.cookiejar.Get(req, "auth")
+func (a Authorizer) Authorize(rw http.ResponseWriter, req *http.Request) (*UserData, error) {
+	session, err := a.cookiejar.Get(req, "auth")
 	if err != nil {
-		if redirectWithMessage {
-			a.goBack(rw, req)
-		}
-		return mkerror("new authorization session")
+		return nil, mkerror("new authorization session")
 	}
-	/*if authSession.IsNew {
-	    if redirectWithMessage {
-	        a.goBack(rw, req)
-	        a.addMessage(rw, req, "Log in to do that.")
-	    }
-	    return mkerror("no session existed")
-	}*/
-	username := authSession.Values["username"]
-	if !authSession.IsNew && username != nil {
-		_, err := a.backend.User(username.(string))
-		if err == ErrMissingUser {
-			authSession.Options.MaxAge = -1 // kill the cookie
-			authSession.Save(req, rw)
-			if redirectWithMessage {
-				a.goBack(rw, req)
-				a.addMessage(rw, req, "Log in to do that.")
-			}
-			return mkerror("user not found")
-		} else if err != nil {
-			return mkerror(err.Error())
-		}
-	}
+	username := session.Values["username"]
 	if username == nil {
-		if redirectWithMessage {
-			a.goBack(rw, req)
-			a.addMessage(rw, req, "Log in to do that.")
-		}
-		return mkerror("user not logged in")
+		return nil, mkerror("user not logged in")
 	}
-	return nil
+	if name, ok := username.(string); ok {
+		user, err := a.backend.User(name)
+		if err == ErrMissingUser {
+			session.Options.MaxAge = -1 // kill the cookie
+			session.Save(req, rw)
+			return nil, mkerror("user not found")
+		} else if err != nil {
+			return nil, mkerror(err.Error())
+		}
+		return &user, nil
+	}
+	return nil, mkerror("user not found")
 }
 
 // AuthorizeRole runs Authorize on a user, then makes sure their role is at
 // least as high as the specified one, failing if not.
-func (a Authorizer) AuthorizeRole(rw http.ResponseWriter, req *http.Request, role string, redirectWithMessage bool) error {
+func (a Authorizer) Satisfy(user *UserData, role string) bool {
 	r, ok := a.roles[role]
 	if !ok {
-		return mkerror("role not found")
+		return false
 	}
-	if err := a.Authorize(rw, req, redirectWithMessage); err != nil {
-		return mkerror(err.Error())
-	}
-	authSession, _ := a.cookiejar.Get(req, "auth") // should I check err? I've already checked in call to Authorize
-	username := authSession.Values["username"]
-	if user, err := a.backend.User(username.(string)); err == nil {
-		if a.roles[user.Role] >= r {
-			return nil
-		}
-		a.addMessage(rw, req, "You don't have sufficient privileges.")
-		return mkerror("user doesn't have high enough role")
-	}
-	return mkerror("user not found")
-}
-
-// CurrentUser returns the currently logged in user and a boolean validating
-// the information.
-func (a Authorizer) CurrentUser(rw http.ResponseWriter, req *http.Request) (user UserData, e error) {
-	if err := a.Authorize(rw, req, false); err != nil {
-		return user, mkerror(err.Error())
-	}
-	authSession, _ := a.cookiejar.Get(req, "auth")
-
-	username, ok := authSession.Values["username"].(string)
-	if !ok {
-		return user, mkerror("User not found in authsession")
-	}
-	return a.backend.User(username)
+	return a.roles[user.Role] >= r
 }
 
 // Logout clears an authentication session and add a logged out message.

--- a/auth.go
+++ b/auth.go
@@ -19,18 +19,19 @@
 package httpauth
 
 import (
-    "code.google.com/p/go.crypto/bcrypt"
-    "errors"
-    "github.com/gorilla/sessions"
-    "net/http"
+	"errors"
+	"net/http"
+
+	"github.com/gorilla/sessions"
+	"golang.org/x/crypto/bcrypt"
 )
 
 // ErrDeleteNull is returned by DeleteUser when that user didn't exist at the
 // time of call.
 // ErrMissingUser is returned by Users when a user is not found.
 var (
-    ErrDeleteNull = mkerror("deleting non-existant user")
-    ErrMissingUser = mkerror("can't find user")
+	ErrDeleteNull  = mkerror("deleting non-existant user")
+	ErrMissingUser = mkerror("can't find user")
 )
 
 // Role represents an interal role. Roles are essentially a string mapped to an
@@ -42,49 +43,49 @@ type Role int
 // users, you should not specify a hash; it will be generated in the Register
 // and Update functions.
 type UserData struct {
-    Username string `bson:"Username"`
-    Email    string `bson:"Email"`
-    Hash     []byte `bson:"Hash"`
-    Role     string `bson:"Role"`
+	Username string `bson:"Username"`
+	Email    string `bson:"Email"`
+	Hash     []byte `bson:"Hash"`
+	Role     string `bson:"Role"`
 }
 
 // Authorizer structures contain the store of user session cookies a reference
 // to a backend storage system.
 type Authorizer struct {
-    cookiejar   *sessions.CookieStore
-    backend     AuthBackend
-    defaultRole string
-    roles       map[string]Role
+	cookiejar   *sessions.CookieStore
+	backend     AuthBackend
+	defaultRole string
+	roles       map[string]Role
 }
 
 // The AuthBackend interface defines a set of methods an AuthBackend must
 // implement.
 type AuthBackend interface {
-    SaveUser(u UserData) error
-    User(username string) (user UserData, e error)
-    Users() (users []UserData, e error)
-    DeleteUser(username string) error
-    Close()
+	SaveUser(u UserData) error
+	User(username string) (user UserData, e error)
+	Users() (users []UserData, e error)
+	DeleteUser(username string) error
+	Close()
 }
 
 // Helper function to add a user directed message to a message queue.
 func (a Authorizer) addMessage(rw http.ResponseWriter, req *http.Request, message string) {
-    messageSession, _ := a.cookiejar.Get(req, "messages")
-    defer messageSession.Save(req, rw)
-    messageSession.AddFlash(message)
+	messageSession, _ := a.cookiejar.Get(req, "messages")
+	defer messageSession.Save(req, rw)
+	messageSession.AddFlash(message)
 }
 
 // Helper function to save a redirect to the page a user tried to visit before
 // logging in.
 func (a Authorizer) goBack(rw http.ResponseWriter, req *http.Request) {
-    redirectSession, _ := a.cookiejar.Get(req, "redirects")
-    defer redirectSession.Save(req, rw)
-    redirectSession.Flashes()
-    redirectSession.AddFlash(req.URL.Path)
+	redirectSession, _ := a.cookiejar.Get(req, "redirects")
+	defer redirectSession.Save(req, rw)
+	redirectSession.Flashes()
+	redirectSession.AddFlash(req.URL.Path)
 }
 
 func mkerror(msg string) error {
-    return errors.New("httpauth: " + msg)
+	return errors.New("httpauth: " + msg)
 }
 
 // NewAuthorizer returns a new Authorizer given an AuthBackend, a cookie store
@@ -101,44 +102,44 @@ func mkerror(msg string) error {
 //     roles["admin"] = 4
 //     roles["moderator"] = 3
 func NewAuthorizer(backend AuthBackend, key []byte, defaultRole string, roles map[string]Role) (Authorizer, error) {
-    var a Authorizer
-    a.cookiejar = sessions.NewCookieStore([]byte(key))
-    a.backend = backend
-    a.roles = roles
-    a.defaultRole = defaultRole
-    if _, ok := roles[defaultRole]; !ok {
-        return a, mkerror("httpauth: defaultRole missing")
-    }
-    return a, nil
+	var a Authorizer
+	a.cookiejar = sessions.NewCookieStore([]byte(key))
+	a.backend = backend
+	a.roles = roles
+	a.defaultRole = defaultRole
+	if _, ok := roles[defaultRole]; !ok {
+		return a, mkerror("httpauth: defaultRole missing")
+	}
+	return a, nil
 }
 
 // Login logs a user in. They will be redirected to dest or to the last
 // location an authorization redirect was triggered (if found) on success. A
 // message will be added to the session on failure with the reason.
 func (a Authorizer) Login(rw http.ResponseWriter, req *http.Request, u string, p string, dest string) error {
-    session, _ := a.cookiejar.Get(req, "auth")
-    if session.Values["username"] != nil {
-        return mkerror("already authenticated")
-    }
-    if user, err := a.backend.User(u); err == nil {
-        verify := bcrypt.CompareHashAndPassword(user.Hash, []byte(u+p))
-        if verify != nil {
-            a.addMessage(rw, req, "Invalid username or password.")
-            return mkerror("password doesn't match")
-        }
-    } else {
-        a.addMessage(rw, req, "Invalid username or password.")
-        return mkerror("user not found")
-    }
-    session.Values["username"] = u
-    session.Save(req, rw)
+	session, _ := a.cookiejar.Get(req, "auth")
+	if session.Values["username"] != nil {
+		return mkerror("already authenticated")
+	}
+	if user, err := a.backend.User(u); err == nil {
+		verify := bcrypt.CompareHashAndPassword(user.Hash, []byte(u+p))
+		if verify != nil {
+			a.addMessage(rw, req, "Invalid username or password.")
+			return mkerror("password doesn't match")
+		}
+	} else {
+		a.addMessage(rw, req, "Invalid username or password.")
+		return mkerror("user not found")
+	}
+	session.Values["username"] = u
+	session.Save(req, rw)
 
-    redirectSession, _ := a.cookiejar.Get(req, "redirects")
-    if flashes := redirectSession.Flashes(); len(flashes) > 0 {
-        dest = flashes[0].(string)
-    }
-    http.Redirect(rw, req, dest, http.StatusSeeOther)
-    return nil
+	redirectSession, _ := a.cookiejar.Get(req, "redirects")
+	if flashes := redirectSession.Flashes(); len(flashes) > 0 {
+		dest = flashes[0].(string)
+	}
+	http.Redirect(rw, req, dest, http.StatusSeeOther)
+	return nil
 }
 
 // Register and save a new user. Returns an error and adds a message if the
@@ -147,94 +148,94 @@ func (a Authorizer) Login(rw http.ResponseWriter, req *http.Request, u string, p
 // Pass in a instance of UserData with at least a username and email specified. If no role
 // is given, the default one is used.
 func (a Authorizer) Register(rw http.ResponseWriter, req *http.Request, user UserData, password string) error {
-    if user.Username == "" {
-        return mkerror("no username given")
-    }
-    if user.Email == "" {
-        return mkerror("no email given")
-    }
-    if user.Hash != nil {
-        return mkerror("hash will be overwritten")
-    }
-    if password == "" {
-        return mkerror("no password given")
-    }
+	if user.Username == "" {
+		return mkerror("no username given")
+	}
+	if user.Email == "" {
+		return mkerror("no email given")
+	}
+	if user.Hash != nil {
+		return mkerror("hash will be overwritten")
+	}
+	if password == "" {
+		return mkerror("no password given")
+	}
 
-    // Validate username
-    _, err := a.backend.User(user.Username)
-    if err == nil {
-        a.addMessage(rw, req, "Username has been taken.")
-        return mkerror("user already exists")
-    } else if err != ErrMissingUser {
-        if err != nil {
-            return mkerror(err.Error())
-        }
-        return nil
-    }
+	// Validate username
+	_, err := a.backend.User(user.Username)
+	if err == nil {
+		a.addMessage(rw, req, "Username has been taken.")
+		return mkerror("user already exists")
+	} else if err != ErrMissingUser {
+		if err != nil {
+			return mkerror(err.Error())
+		}
+		return nil
+	}
 
-    // Generate and save hash
-    hash, err := bcrypt.GenerateFromPassword([]byte(user.Username+password), 8)
-    if err != nil {
-        return mkerror("couldn't save password: " + err.Error())
-    }
-    user.Hash = hash
+	// Generate and save hash
+	hash, err := bcrypt.GenerateFromPassword([]byte(user.Username+password), 8)
+	if err != nil {
+		return mkerror("couldn't save password: " + err.Error())
+	}
+	user.Hash = hash
 
-    // Validate role
-    if user.Role == "" {
-        user.Role = a.defaultRole
-    } else {
-        if _, ok := a.roles[user.Role]; !ok {
-            return mkerror("non-existant role")
-        }
-    }
+	// Validate role
+	if user.Role == "" {
+		user.Role = a.defaultRole
+	} else {
+		if _, ok := a.roles[user.Role]; !ok {
+			return mkerror("non-existant role")
+		}
+	}
 
-    err = a.backend.SaveUser(user)
-    if err != nil {
-        a.addMessage(rw, req, err.Error())
-        return mkerror(err.Error())
-    }
-    return nil
+	err = a.backend.SaveUser(user)
+	if err != nil {
+		a.addMessage(rw, req, err.Error())
+		return mkerror(err.Error())
+	}
+	return nil
 }
 
 // Update changes data for an existing user. Needs thought...
 func (a Authorizer) Update(rw http.ResponseWriter, req *http.Request, p string, e string) error {
-    var (
-        hash  []byte
-        email string
-    )
-    authSession, err := a.cookiejar.Get(req, "auth")
-    username, ok := authSession.Values["username"].(string)
-    if !ok {
-        return mkerror("not logged in")
-    }
-    user, err := a.backend.User(username)
-    if err == ErrMissingUser {
-        a.addMessage(rw, req, "User doesn't exist.")
-        return mkerror("user doesn't exists")
-    } else if err != nil {
-        return mkerror(err.Error())
-    }
-    if p != "" {
-        hash, err = bcrypt.GenerateFromPassword([]byte(username+p), 8)
-        if err != nil {
-            return mkerror("couldn't save password: " + err.Error())
-        }
-    } else {
-        hash = user.Hash
-    }
-    if e != "" {
-        email = e
-    } else {
-        email = user.Email
-    }
+	var (
+		hash  []byte
+		email string
+	)
+	authSession, err := a.cookiejar.Get(req, "auth")
+	username, ok := authSession.Values["username"].(string)
+	if !ok {
+		return mkerror("not logged in")
+	}
+	user, err := a.backend.User(username)
+	if err == ErrMissingUser {
+		a.addMessage(rw, req, "User doesn't exist.")
+		return mkerror("user doesn't exists")
+	} else if err != nil {
+		return mkerror(err.Error())
+	}
+	if p != "" {
+		hash, err = bcrypt.GenerateFromPassword([]byte(username+p), 8)
+		if err != nil {
+			return mkerror("couldn't save password: " + err.Error())
+		}
+	} else {
+		hash = user.Hash
+	}
+	if e != "" {
+		email = e
+	} else {
+		email = user.Email
+	}
 
-    newuser := UserData{username, email, hash, user.Role}
+	newuser := UserData{username, email, hash, user.Role}
 
-    err = a.backend.SaveUser(newuser)
-    if err != nil {
-        a.addMessage(rw, req, err.Error())
-    }
-    return nil
+	err = a.backend.SaveUser(newuser)
+	if err != nil {
+		a.addMessage(rw, req, err.Error())
+	}
+	return nil
 }
 
 // Authorize checks if a user is logged in and returns an error on failed
@@ -243,112 +244,112 @@ func (a Authorizer) Update(rw http.ResponseWriter, req *http.Request, p string, 
 // messages list. The next time the user logs in, they will be redirected back
 // to the saved page.
 func (a Authorizer) Authorize(rw http.ResponseWriter, req *http.Request, redirectWithMessage bool) error {
-    authSession, err := a.cookiejar.Get(req, "auth")
-    if err != nil {
-        if redirectWithMessage {
-            a.goBack(rw, req)
-        }
-        return mkerror("new authorization session")
-    }
-    /*if authSession.IsNew {
-        if redirectWithMessage {
-            a.goBack(rw, req)
-            a.addMessage(rw, req, "Log in to do that.")
-        }
-        return mkerror("no session existed")
-    }*/
-    username := authSession.Values["username"]
-    if !authSession.IsNew && username != nil {
-        _, err := a.backend.User(username.(string))
-        if err == ErrMissingUser {
-            authSession.Options.MaxAge = -1 // kill the cookie
-            authSession.Save(req, rw)
-            if redirectWithMessage {
-                a.goBack(rw, req)
-                a.addMessage(rw, req, "Log in to do that.")
-            }
-            return mkerror("user not found")
-        } else if err != nil {
-            return mkerror(err.Error())
-        }
-    }
-    if username == nil {
-        if redirectWithMessage {
-            a.goBack(rw, req)
-            a.addMessage(rw, req, "Log in to do that.")
-        }
-        return mkerror("user not logged in")
-    }
-    return nil
+	authSession, err := a.cookiejar.Get(req, "auth")
+	if err != nil {
+		if redirectWithMessage {
+			a.goBack(rw, req)
+		}
+		return mkerror("new authorization session")
+	}
+	/*if authSession.IsNew {
+	    if redirectWithMessage {
+	        a.goBack(rw, req)
+	        a.addMessage(rw, req, "Log in to do that.")
+	    }
+	    return mkerror("no session existed")
+	}*/
+	username := authSession.Values["username"]
+	if !authSession.IsNew && username != nil {
+		_, err := a.backend.User(username.(string))
+		if err == ErrMissingUser {
+			authSession.Options.MaxAge = -1 // kill the cookie
+			authSession.Save(req, rw)
+			if redirectWithMessage {
+				a.goBack(rw, req)
+				a.addMessage(rw, req, "Log in to do that.")
+			}
+			return mkerror("user not found")
+		} else if err != nil {
+			return mkerror(err.Error())
+		}
+	}
+	if username == nil {
+		if redirectWithMessage {
+			a.goBack(rw, req)
+			a.addMessage(rw, req, "Log in to do that.")
+		}
+		return mkerror("user not logged in")
+	}
+	return nil
 }
 
 // AuthorizeRole runs Authorize on a user, then makes sure their role is at
 // least as high as the specified one, failing if not.
 func (a Authorizer) AuthorizeRole(rw http.ResponseWriter, req *http.Request, role string, redirectWithMessage bool) error {
-    r, ok := a.roles[role]
-    if !ok {
-        return mkerror("role not found")
-    }
-    if err := a.Authorize(rw, req, redirectWithMessage); err != nil {
-        return mkerror(err.Error())
-    }
-    authSession, _ := a.cookiejar.Get(req, "auth") // should I check err? I've already checked in call to Authorize
-    username := authSession.Values["username"]
-    if user, err := a.backend.User(username.(string)); err == nil {
-        if a.roles[user.Role] >= r {
-            return nil
-        }
-        a.addMessage(rw, req, "You don't have sufficient privileges.")
-        return mkerror("user doesn't have high enough role")
-    }
-    return mkerror("user not found")
+	r, ok := a.roles[role]
+	if !ok {
+		return mkerror("role not found")
+	}
+	if err := a.Authorize(rw, req, redirectWithMessage); err != nil {
+		return mkerror(err.Error())
+	}
+	authSession, _ := a.cookiejar.Get(req, "auth") // should I check err? I've already checked in call to Authorize
+	username := authSession.Values["username"]
+	if user, err := a.backend.User(username.(string)); err == nil {
+		if a.roles[user.Role] >= r {
+			return nil
+		}
+		a.addMessage(rw, req, "You don't have sufficient privileges.")
+		return mkerror("user doesn't have high enough role")
+	}
+	return mkerror("user not found")
 }
 
 // CurrentUser returns the currently logged in user and a boolean validating
 // the information.
 func (a Authorizer) CurrentUser(rw http.ResponseWriter, req *http.Request) (user UserData, e error) {
-    if err := a.Authorize(rw, req, false); err != nil {
-        return user, mkerror(err.Error())
-    }
-    authSession, _ := a.cookiejar.Get(req, "auth")
+	if err := a.Authorize(rw, req, false); err != nil {
+		return user, mkerror(err.Error())
+	}
+	authSession, _ := a.cookiejar.Get(req, "auth")
 
-    username, ok := authSession.Values["username"].(string)
-    if !ok {
-        return user, mkerror("User not found in authsession")
-    }
-    return a.backend.User(username)
+	username, ok := authSession.Values["username"].(string)
+	if !ok {
+		return user, mkerror("User not found in authsession")
+	}
+	return a.backend.User(username)
 }
 
 // Logout clears an authentication session and add a logged out message.
 func (a Authorizer) Logout(rw http.ResponseWriter, req *http.Request) error {
-    session, _ := a.cookiejar.Get(req, "auth")
-    defer session.Save(req, rw)
+	session, _ := a.cookiejar.Get(req, "auth")
+	defer session.Save(req, rw)
 
-    session.Options.MaxAge = -1 // kill the cookie
-    a.addMessage(rw, req, "Logged out.")
-    return nil
+	session.Options.MaxAge = -1 // kill the cookie
+	a.addMessage(rw, req, "Logged out.")
+	return nil
 }
 
 // DeleteUser removes a user from the Authorize. ErrMissingUser is returned if
 // the user to be deleted isn't found.
 func (a Authorizer) DeleteUser(username string) error {
-    err := a.backend.DeleteUser(username)
-    if err != nil && err != ErrDeleteNull {
-        return mkerror(err.Error())
-    }
-    return err
+	err := a.backend.DeleteUser(username)
+	if err != nil && err != ErrDeleteNull {
+		return mkerror(err.Error())
+	}
+	return err
 }
 
 // Messages fetches a list of saved messages. Use this to get a nice message to print to
 // the user on a login page or registration page in case something happened
 // (username taken, invalid credentials, successful logout, etc).
 func (a Authorizer) Messages(rw http.ResponseWriter, req *http.Request) []string {
-    session, _ := a.cookiejar.Get(req, "messages")
-    flashes := session.Flashes()
-    session.Save(req, rw)
-    var messages []string
-    for _, val := range flashes {
-        messages = append(messages, val.(string))
-    }
-    return messages
+	session, _ := a.cookiejar.Get(req, "messages")
+	flashes := session.Flashes()
+	session.Save(req, rw)
+	var messages []string
+	for _, val := range flashes {
+		messages = append(messages, val.(string))
+	}
+	return messages
 }

--- a/gobfile.go
+++ b/gobfile.go
@@ -1,101 +1,101 @@
 package httpauth
 
 import (
-    "encoding/gob"
-    "os"
-    "fmt"
-    "errors"
+	"encoding/gob"
+	"errors"
+	"fmt"
+	"os"
 )
 
 // ErrMissingBackend is returned by NewGobFileAuthBackend when the file doesn't
 // exist. Be sure to create (or touch) it if using brand new backend or
 // resetting backend.
 var (
-    ErrMissingBackend = errors.New("gobfilebackend: missing backend")
+	ErrMissingBackend = errors.New("gobfilebackend: missing backend")
 )
 
 // GobFileAuthBackend stores user data and the location of the gob file.
 type GobFileAuthBackend struct {
-    filepath string
-    users    map[string]UserData
+	filepath string
+	users    map[string]UserData
 }
 
 // NewGobFileAuthBackend initializes a new backend by loading a map of users
 // from a file.
 // If the file doesn't exist, returns an error.
 func NewGobFileAuthBackend(filepath string) (b GobFileAuthBackend, e error) {
-    b.filepath = filepath
-    if _, err := os.Stat(b.filepath); err == nil {
-        f, err := os.Open(b.filepath)
-        defer f.Close()
-        if err != nil {
-            return b, fmt.Errorf("gobfilebackend: %v", err.Error())
-        }
-        dec := gob.NewDecoder(f)
-        dec.Decode(&b.users)
-    } else if !os.IsNotExist(err) {
-        return b, fmt.Errorf("gobfilebackend: %v", err.Error())
-    } else {
-        return b, ErrMissingBackend
-    }
-    if b.users == nil {
-        b.users = make(map[string]UserData)
-    }
-    return b, nil
+	b.filepath = filepath
+	if _, err := os.Stat(b.filepath); err == nil {
+		f, err := os.Open(b.filepath)
+		defer f.Close()
+		if err != nil {
+			return b, fmt.Errorf("gobfilebackend: %v", err.Error())
+		}
+		dec := gob.NewDecoder(f)
+		dec.Decode(&b.users)
+	} else if !os.IsNotExist(err) {
+		return b, fmt.Errorf("gobfilebackend: %v", err.Error())
+	} else {
+		return b, ErrMissingBackend
+	}
+	if b.users == nil {
+		b.users = make(map[string]UserData)
+	}
+	return b, nil
 }
 
 // User returns the user with the given username. Error is set to
 // ErrMissingUser if user is not found.
 func (b GobFileAuthBackend) User(username string) (user UserData, e error) {
-    if user, ok := b.users[username]; ok {
-        return user, nil
-    }
-    return user, ErrMissingUser
+	if user, ok := b.users[username]; ok {
+		return user, nil
+	}
+	return user, ErrMissingUser
 }
 
 // Users returns a slice of all users.
 func (b GobFileAuthBackend) Users() (us []UserData, e error) {
-    for _, user := range b.users {
-        us = append(us, user)
-    }
-    return
+	for _, user := range b.users {
+		us = append(us, user)
+	}
+	return
 }
 
 // SaveUser adds a new user, replacing one with the same username, and saves a
 // gob file.
 func (b GobFileAuthBackend) SaveUser(user UserData) error {
-    b.users[user.Username] = user
-    err := b.save()
-    return err
+	b.users[user.Name] = user
+	err := b.save()
+	return err
 }
 
 func (b GobFileAuthBackend) save() error {
-    f, err := os.Create(b.filepath)
-    defer f.Close()
-    if err != nil {
-        return errors.New("gobfilebackend: failed to edit auth file")
-    }
-    enc := gob.NewEncoder(f)
-    err = enc.Encode(b.users)
-    if err != nil {
-        fmt.Errorf("gobfilebackend: save: %v", err)
-    }
-    return nil
+	f, err := os.Create(b.filepath)
+	defer f.Close()
+	if err != nil {
+		return errors.New("gobfilebackend: failed to edit auth file")
+	}
+	enc := gob.NewEncoder(f)
+	err = enc.Encode(b.users)
+	if err != nil {
+		fmt.Errorf("gobfilebackend: save: %v", err)
+	}
+	return nil
 }
 
 // DeleteUser removes a user, raising ErrDeleteNull if that user was missing.
 func (b GobFileAuthBackend) DeleteUser(username string) error {
-    _, err := b.User(username)
-    if err == ErrMissingUser {
-        return ErrDeleteNull
-    } else if err != nil {
-        return fmt.Errorf("gobfilebackend: %v", err)
-    }
-    delete(b.users, username)
-    return b.save()
+	_, err := b.User(username)
+	if err == ErrMissingUser {
+		return ErrDeleteNull
+	} else if err != nil {
+		return fmt.Errorf("gobfilebackend: %v", err)
+	}
+	delete(b.users, username)
+	return b.save()
 }
 
 // Close cleans up the backend. Currently a no-op for gobfiles.
 func (b GobFileAuthBackend) Close() {
-    ;
+
 }

--- a/mongoBackend.go
+++ b/mongoBackend.go
@@ -1,25 +1,26 @@
 package httpauth
 
 import (
-    "gopkg.in/mgo.v2"
-    "gopkg.in/mgo.v2/bson"
-    "errors"
+	"errors"
+
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 )
 
 // MongodbAuthBackend stores database connection information.
 type MongodbAuthBackend struct {
-    mongoURL string
-    database string
-    session  *mgo.Session
+	mongoURL string
+	database string
+	session  *mgo.Session
 }
 
 func (b MongodbAuthBackend) connect() *mgo.Collection {
-    session := b.session.Copy()
-    return session.DB(b.database).C("goauth")
+	session := b.session.Copy()
+	return session.DB(b.database).C("goauth")
 }
 
 func mkmgoerror(msg string) error {
-    return errors.New("mongobackend: " + msg)
+	return errors.New("mongobackend: " + msg)
 }
 
 // NewMongodbBackend initializes a new backend.
@@ -28,84 +29,84 @@ func mkmgoerror(msg string) error {
 //     backend = httpauth.MongodbAuthBackend("mongodb://127.0.0.1/", "auth")
 //     defer backend.Close()
 func NewMongodbBackend(mongoURL string, database string) (b MongodbAuthBackend, e error) {
-    // Set up connection to database
-    b.mongoURL = mongoURL
-    b.database = database
-    session, err := mgo.Dial(b.mongoURL)
-    if err != nil {
-        return b, mkmgoerror(err.Error())
-    }
-    err = session.Ping()
-    if err != nil {
-        return b, mkmgoerror(err.Error())
-    }
+	// Set up connection to database
+	b.mongoURL = mongoURL
+	b.database = database
+	session, err := mgo.Dial(b.mongoURL)
+	if err != nil {
+		return b, mkmgoerror(err.Error())
+	}
+	err = session.Ping()
+	if err != nil {
+		return b, mkmgoerror(err.Error())
+	}
 
-    // Ensure that the Username field is unique
-    index := mgo.Index{
-        Key: []string{"Username"},
-        Unique: true,
-    }
-    err = session.DB(b.database).C("goauth").EnsureIndex(index)
-    if err != nil {
-        return b, mkmgoerror(err.Error())
-    }
-    b.session = session
-    return
+	// Ensure that the Name field is unique
+	index := mgo.Index{
+		Key:    []string{"Name"},
+		Unique: true,
+	}
+	err = session.DB(b.database).C("goauth").EnsureIndex(index)
+	if err != nil {
+		return b, mkmgoerror(err.Error())
+	}
+	b.session = session
+	return
 }
 
 // User returns the user with the given username. Error is set to
 // ErrMissingUser if user is not found.
 func (b MongodbAuthBackend) User(username string) (user UserData, e error) {
-    var result UserData
+	var result UserData
 
-    c := b.connect()
-    defer c.Database.Session.Close()
+	c := b.connect()
+	defer c.Database.Session.Close()
 
-    err := c.Find(bson.M{"Username": username}).One(&result)
-    if err != nil {
-        return result, ErrMissingUser
-    }
-    return result, nil
+	err := c.Find(bson.M{"Name": username}).One(&result)
+	if err != nil {
+		return result, ErrMissingUser
+	}
+	return result, nil
 }
 
 // Users returns a slice of all users.
 func (b MongodbAuthBackend) Users() (us []UserData, e error) {
-    c := b.connect()
-    defer c.Database.Session.Close()
+	c := b.connect()
+	defer c.Database.Session.Close()
 
-    err := c.Find(bson.M{}).All(&us)
-    if err != nil {
-        return us, mkmgoerror(err.Error())
-    }
-    return
+	err := c.Find(bson.M{}).All(&us)
+	if err != nil {
+		return us, mkmgoerror(err.Error())
+	}
+	return
 }
 
 // SaveUser adds a new user, replacing if the same username is in use.
 func (b MongodbAuthBackend) SaveUser(user UserData) error {
-    c := b.connect()
-    defer c.Database.Session.Close()
+	c := b.connect()
+	defer c.Database.Session.Close()
 
-    _, err := c.Upsert(bson.M{ "Username": user.Username }, bson.M{ "$set": user })
-    return err
+	_, err := c.Upsert(bson.M{"Name": user.Name}, bson.M{"$set": user})
+	return err
 }
 
 // DeleteUser removes a user. ErrNotFound is returned if the user isn't found.
 func (b MongodbAuthBackend) DeleteUser(username string) error {
-    c := b.connect()
-    defer c.Database.Session.Close()
+	c := b.connect()
+	defer c.Database.Session.Close()
 
-    // raises error if "username" doesn't exist
-    err := c.Remove(bson.M{"Username": username})
-    if err == mgo.ErrNotFound {
-        return ErrDeleteNull
-    }
-    return err
+	// raises error if "username" doesn't exist
+	err := c.Remove(bson.M{"Name": username})
+	if err == mgo.ErrNotFound {
+		return ErrDeleteNull
+	}
+	return err
 }
 
 // Close cleans up the backend once done with. This should be called before
 // program exit.
 func (b MongodbAuthBackend) Close() {
-    if b.session != nil {
-        b.session.Close()
-    }
+	if b.session != nil {
+		b.session.Close()
+	}
 }

--- a/sqlBackend.go
+++ b/sqlBackend.go
@@ -1,28 +1,28 @@
 package httpauth
 
 import (
-    "database/sql"
-    "fmt"
-    "os"
-    "errors"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
 )
 
 // SqlAuthBackend database and database connection information.
 type SqlAuthBackend struct {
-    driverName     string
-    dataSourceName string
-    db             *sql.DB
+	driverName     string
+	dataSourceName string
+	db             *sql.DB
 
-    // prepared statements
-    userStmt       *sql.Stmt
-    usersStmt      *sql.Stmt
-    insertStmt     *sql.Stmt
-    updateStmt     *sql.Stmt
-    deleteStmt     *sql.Stmt
+	// prepared statements
+	userStmt   *sql.Stmt
+	usersStmt  *sql.Stmt
+	insertStmt *sql.Stmt
+	updateStmt *sql.Stmt
+	deleteStmt *sql.Stmt
 }
 
 func mksqlerror(msg string) error {
-    return errors.New("sqlbackend: " + msg)
+	return errors.New("sqlbackend: " + msg)
 }
 
 // NewSqlAuthBackend initializes a new backend by testing the database
@@ -40,149 +40,149 @@ func mksqlerror(msg string) error {
 // using sql for your own purposes, you'll need to use the underscore to import
 // for side effects; see http://golang.org/doc/effective_go.html#blank_import.
 func NewSqlAuthBackend(driverName, dataSourceName string) (b SqlAuthBackend, e error) {
-    b.driverName = driverName
-    b.dataSourceName = dataSourceName
-    if driverName == "sqlite3" {
-        if _, err := os.Stat(dataSourceName); os.IsNotExist(err) {
-            return b, ErrMissingBackend
-        }
-    }
-    db, err := sql.Open(driverName, dataSourceName)
-    if err != nil {
-        return b, mksqlerror(err.Error())
-    }
-    err = db.Ping()
-    if err != nil {
-        return b, mksqlerror(err.Error())
-    }
-    b.db = db
-    _, err = db.Exec(`create table if not exists goauth (Username varchar(255), Email varchar(255), Hash varchar(255), Role varchar(255), primary key (Username))`)
-    if err != nil {
-        return b, mksqlerror(err.Error())
-    }
+	b.driverName = driverName
+	b.dataSourceName = dataSourceName
+	if driverName == "sqlite3" {
+		if _, err := os.Stat(dataSourceName); os.IsNotExist(err) {
+			return b, ErrMissingBackend
+		}
+	}
+	db, err := sql.Open(driverName, dataSourceName)
+	if err != nil {
+		return b, mksqlerror(err.Error())
+	}
+	err = db.Ping()
+	if err != nil {
+		return b, mksqlerror(err.Error())
+	}
+	b.db = db
+	_, err = db.Exec(`create table if not exists goauth (Name varchar(255), Email varchar(255), Hash varchar(255), Role varchar(255), primary key (Name))`)
+	if err != nil {
+		return b, mksqlerror(err.Error())
+	}
 
-    // prepare statements for concurrent use and better preformance
-    //
-    // NOTE:
-    // I don't want to have to check if it's postgres, but postgres uses
-    // different tokens for placeholders. :( Also be aware that postgres
-    // lowercases all these column names.
-    //
-    // Thanks to mjhall for letting me know about this.
-    if driverName == "postgres" {
-        b.userStmt, err = db.Prepare(`select Email, Hash, Role from goauth where Username = $1`)
-        if err != nil {
-            return b, mksqlerror(fmt.Sprintf("userstmt: %v", err))
-        }
-        b.usersStmt, err = db.Prepare(`select Username, Email, Hash, Role from goauth`)
-        if err != nil {
-            return b, mksqlerror(fmt.Sprintf("usersstmt: %v", err))
-        }
-        b.insertStmt, err = db.Prepare(`insert into goauth (Username, Email, Hash, Role) values ($1, $2, $3, $4)`)
-        if err != nil {
-            return b, mksqlerror(fmt.Sprintf("insertstmt: %v", err))
-        }
-        b.updateStmt, err = db.Prepare(`update goauth set Email = $1, Hash = $2, Role = $3 where Username = $4`)
-        if err != nil {
-            return b, mksqlerror(fmt.Sprintf("updatestmt: %v", err))
-        }
-        b.deleteStmt, err = db.Prepare(`delete from goauth where Username = $1`)
-        if err != nil {
-            return b, mksqlerror(fmt.Sprintf("deletestmt: %v", err))
-        }
-    } else {
-        b.userStmt, err = db.Prepare(`select Email, Hash, Role from goauth where Username = ?`)
-        if err != nil {
-            return b, mksqlerror(fmt.Sprintf("userstmt: %v", err))
-        }
-        b.usersStmt, err = db.Prepare(`select Username, Email, Hash, Role from goauth`)
-        if err != nil {
-            return b, mksqlerror(fmt.Sprintf("usersstmt: %v", err))
-        }
-        b.insertStmt, err = db.Prepare(`insert into goauth (Username, Email, Hash, Role) values (?, ?, ?, ?)`)
-        if err != nil {
-            return b, mksqlerror(fmt.Sprintf("insertstmt: %v", err))
-        }
-        b.updateStmt, err = db.Prepare(`update goauth set Email = ?, Hash = ?, Role = ? where Username = ?`)
-        if err != nil {
-            return b, mksqlerror(fmt.Sprintf("updatestmt: %v", err))
-        }
-        b.deleteStmt, err = db.Prepare(`delete from goauth where Username = ?`)
-        if err != nil {
-            return b, mksqlerror(fmt.Sprintf("deletestmt: %v", err))
-        }
-    }
+	// prepare statements for concurrent use and better preformance
+	//
+	// NOTE:
+	// I don't want to have to check if it's postgres, but postgres uses
+	// different tokens for placeholders. :( Also be aware that postgres
+	// lowercases all these column names.
+	//
+	// Thanks to mjhall for letting me know about this.
+	if driverName == "postgres" {
+		b.userStmt, err = db.Prepare(`select Email, Hash, Role from goauth where Name = $1`)
+		if err != nil {
+			return b, mksqlerror(fmt.Sprintf("userstmt: %v", err))
+		}
+		b.usersStmt, err = db.Prepare(`select Name, Email, Hash, Role from goauth`)
+		if err != nil {
+			return b, mksqlerror(fmt.Sprintf("usersstmt: %v", err))
+		}
+		b.insertStmt, err = db.Prepare(`insert into goauth (Name, Email, Hash, Role) values ($1, $2, $3, $4)`)
+		if err != nil {
+			return b, mksqlerror(fmt.Sprintf("insertstmt: %v", err))
+		}
+		b.updateStmt, err = db.Prepare(`update goauth set Email = $1, Hash = $2, Role = $3 where Name = $4`)
+		if err != nil {
+			return b, mksqlerror(fmt.Sprintf("updatestmt: %v", err))
+		}
+		b.deleteStmt, err = db.Prepare(`delete from goauth where Name = $1`)
+		if err != nil {
+			return b, mksqlerror(fmt.Sprintf("deletestmt: %v", err))
+		}
+	} else {
+		b.userStmt, err = db.Prepare(`select Email, Hash, Role from goauth where Name = ?`)
+		if err != nil {
+			return b, mksqlerror(fmt.Sprintf("userstmt: %v", err))
+		}
+		b.usersStmt, err = db.Prepare(`select Name, Email, Hash, Role from goauth`)
+		if err != nil {
+			return b, mksqlerror(fmt.Sprintf("usersstmt: %v", err))
+		}
+		b.insertStmt, err = db.Prepare(`insert into goauth (Name, Email, Hash, Role) values (?, ?, ?, ?)`)
+		if err != nil {
+			return b, mksqlerror(fmt.Sprintf("insertstmt: %v", err))
+		}
+		b.updateStmt, err = db.Prepare(`update goauth set Email = ?, Hash = ?, Role = ? where Name = ?`)
+		if err != nil {
+			return b, mksqlerror(fmt.Sprintf("updatestmt: %v", err))
+		}
+		b.deleteStmt, err = db.Prepare(`delete from goauth where Name = ?`)
+		if err != nil {
+			return b, mksqlerror(fmt.Sprintf("deletestmt: %v", err))
+		}
+	}
 
-    return b, nil
+	return b, nil
 }
 
 // User returns the user with the given username. Error is set to
 // ErrMissingUser if user is not found.
 func (b SqlAuthBackend) User(username string) (user UserData, e error) {
-    row := b.userStmt.QueryRow(username)
-    err := row.Scan(&user.Email, &user.Hash, &user.Role)
-    if err != nil {
-        if err == sql.ErrNoRows {
-            return user, ErrMissingUser
-        }
-        return user, mksqlerror(err.Error())
-    }
-    user.Username = username
-    return user, nil
+	row := b.userStmt.QueryRow(username)
+	err := row.Scan(&user.Email, &user.Hash, &user.Role)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return user, ErrMissingUser
+		}
+		return user, mksqlerror(err.Error())
+	}
+	user.Name = username
+	return user, nil
 }
 
 // Users returns a slice of all users.
 func (b SqlAuthBackend) Users() (us []UserData, e error) {
-    rows, err := b.usersStmt.Query()
-    if err != nil {
-        return us, mksqlerror(err.Error())
-    }
-    var (
-        username, email, role string
-        hash                  []byte
-    )
-    for rows.Next() {
-        err = rows.Scan(&username, &email, &hash, &role)
-        if err != nil {
-            return us, mksqlerror(err.Error())
-        }
-        us = append(us, UserData{username, email, hash, role})
-    }
-    return us, nil
+	rows, err := b.usersStmt.Query()
+	if err != nil {
+		return us, mksqlerror(err.Error())
+	}
+	var (
+		username, email, role string
+		hash                  []byte
+	)
+	for rows.Next() {
+		err = rows.Scan(&username, &email, &hash, &role)
+		if err != nil {
+			return us, mksqlerror(err.Error())
+		}
+		us = append(us, UserData{username, email, hash, role})
+	}
+	return us, nil
 }
 
 // SaveUser adds a new user, replacing one with the same username.
 func (b SqlAuthBackend) SaveUser(user UserData) (err error) {
-    if _, err := b.User(user.Username); err == nil {
-        _, err = b.updateStmt.Exec(user.Email, user.Hash, user.Role, user.Username)
-    } else {
-        _, err = b.insertStmt.Exec(user.Username, user.Email, user.Hash, user.Role)
-    }
-    return
+	if _, err := b.User(user.Name); err == nil {
+		_, err = b.updateStmt.Exec(user.Email, user.Hash, user.Role, user.Name)
+	} else {
+		_, err = b.insertStmt.Exec(user.Name, user.Email, user.Hash, user.Role)
+	}
+	return
 }
 
 // DeleteUser removes a user, raising ErrDeleteNull if that user was missing.
 func (b SqlAuthBackend) DeleteUser(username string) error {
-    result, err := b.deleteStmt.Exec(username)
-    if err != nil {
-        return mksqlerror(err.Error())
-    }
-    rows, err := result.RowsAffected()
-    if err != nil {
-        return mksqlerror(err.Error())
-    }
-    if rows == 0 {
-        return ErrDeleteNull
-    }
-    return nil
+	result, err := b.deleteStmt.Exec(username)
+	if err != nil {
+		return mksqlerror(err.Error())
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return mksqlerror(err.Error())
+	}
+	if rows == 0 {
+		return ErrDeleteNull
+	}
+	return nil
 }
 
 // Close cleans up the backend by terminating the database connection.
 func (b SqlAuthBackend) Close() {
-    b.db.Close()
-    b.userStmt.Close()
-    b.usersStmt.Close()
-    b.insertStmt.Close()
-    b.updateStmt.Close()
-    b.deleteStmt.Close()
+	b.db.Close()
+	b.userStmt.Close()
+	b.usersStmt.Close()
+	b.insertStmt.Close()
+	b.updateStmt.Close()
+	b.deleteStmt.Close()
 }


### PR DESCRIPTION
Import path for bcrypt has been changed to golang.org/x/crypto/bcrypt.

The rest of the changes are due to automatically "go fmt" that should be done for all go source files.