### PR TITLE
Add functionality to "Update" to allow the username to be specified.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ server
 mongodbtest
 pgdbtest
 test.ldb
+gobfile_test.gob
+httpauth_test_sqlite.db

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,13 @@ language: go
 
 go:
     - tip
+    - 1.5
     - 1.4
     - 1.3
     - 1.2
 
 install:
-    - go get code.google.com/p/go.crypto/bcrypt
+    - go get golang.org/x/crypto/bcrypt
     - go get github.com/gorilla/mux
     - go get github.com/gorilla/sessions
     - go get github.com/go-sql-driver/mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ go:
     - 1.5
     - 1.4
     - 1.3
-    - 1.2
 
 install:
     - go get golang.org/x/crypto/bcrypt

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![Version 2.0.0](https://img.shields.io/badge/version-2.0.0-lightgrey.svg)
 
 NOTE: If upgrading from prior to
-[a66ab9d](https://github.com/apexskier/httpauth/commit/a66ab9d137543fc0c3e56c6fe5d7d377c93087f6), 
+[a66ab9d](https://github.com/apexskier/httpauth/commit/a66ab9d137543fc0c3e56c6fe5d7d377c93087f6),
 you will need to regenerate password hashes.
 
 This package uses the [Gorilla web toolkit](http://www.gorillatoolkit.org/)'s
@@ -45,7 +45,7 @@ func login(rw http.ResponseWriter, req *http.Request) {
 ```
 
 Run `go run server.go` from the examples directory and visit `localhost:8009`
-for an example. You can login with the username and password "admin".
+for an example. You can login with the username "admin" and password "adminadmin".
 
 Tests can be run by simulating Travis CI's build environment. There's a very
 unsafe script --- `start-test-env.sh` that will do this for you.

--- a/auth_test.go
+++ b/auth_test.go
@@ -79,6 +79,28 @@ func TestRegister(t *testing.T) {
 	}
 }
 
+func TestUpdate(t *testing.T) {
+	rw := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/", nil)
+	updatedEmail := "email2@example.com"
+	err := a.Update(rw, req, "username", "", updatedEmail)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if rw.Code != http.StatusOK {
+		t.Fatalf("Update: Wrong status code: %v", rw.Code)
+	}
+
+	user, err := a.backend.User("username")
+	if err != nil {
+		t.Fatalf("Couldn't get updated user: %v", err)
+	}
+
+	if user.Email != updatedEmail {
+		t.Errorf("Updated user's email is %s, expected %s", user.Email, updatedEmail)
+	}
+}
+
 func TestLogin(t *testing.T) {
 	rw := httptest.NewRecorder()
 	req, _ := http.NewRequest("POST", "/", nil)
@@ -154,7 +176,7 @@ func TestAuthorizeRole(t *testing.T) {
 		t.Fatalf("AuthorizeRole error: %v", err) // Should work
 	}
 	if err := a.AuthorizeRole(rw, req, "admin", true); err == nil {
-		t.Fatalf("AuthorizeRole error: didn't restrict lower role user", err) // Should work
+		t.Fatal("AuthorizeRole error: didn't restrict lower role user", err) // Should work
 	}
 }
 

--- a/examples/server.go
+++ b/examples/server.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/trusch/httpauth"
 	"github.com/gorilla/mux"
+	"github.com/turnkey-commerce/httpauth"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -21,7 +21,7 @@ var (
 
 func main() {
 	var err error
-	os.Mkdir(backendfile,0755)
+	os.Mkdir(backendfile, 0755)
 	defer os.Remove(backendfile)
 
 	// create the backend
@@ -128,7 +128,7 @@ func postAddUser(rw http.ResponseWriter, req *http.Request) {
 
 func postChange(rw http.ResponseWriter, req *http.Request) {
 	email := req.PostFormValue("new_email")
-	aaa.Update(rw, req, "", email)
+	aaa.Update(rw, req, "", "", email)
 	http.Redirect(rw, req, "/", http.StatusSeeOther)
 }
 

--- a/gobfile_test.go
+++ b/gobfile_test.go
@@ -1,7 +1,6 @@
 package httpauth
 
 import (
-	"fmt"
 	"os"
 	"testing"
 )
@@ -11,7 +10,6 @@ var gobfile = "gobfile_test.gob"
 
 func TestInitGobFileAuthBackend(t *testing.T) {
 	err := os.Remove(gobfile)
-	fmt.Println(gobfile)
 	b, err := NewGobFileAuthBackend(gobfile)
 	if err != ErrMissingBackend {
 		t.Fatal(err.Error())

--- a/gobfile_test.go
+++ b/gobfile_test.go
@@ -1,26 +1,31 @@
 package httpauth
 
 import (
+	"fmt"
 	"os"
 	"testing"
 )
 
+// Establish new gobfile for testing due to issues with busy process from previous test.
+var gobfile = "gobfile_test.gob"
+
 func TestInitGobFileAuthBackend(t *testing.T) {
-	os.Remove(file)
-	b, err := NewGobFileAuthBackend(file)
+	err := os.Remove(gobfile)
+	fmt.Println(gobfile)
+	b, err := NewGobFileAuthBackend(gobfile)
 	if err != ErrMissingBackend {
 		t.Fatal(err.Error())
 	}
 
-	_, err = os.Create(file)
+	_, err = os.Create(gobfile)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	b, err = NewGobFileAuthBackend(file)
+	b, err = NewGobFileAuthBackend(gobfile)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	if b.filepath != file {
+	if b.filepath != gobfile {
 		t.Fatal("File path not saved.")
 	}
 	if len(b.users) != 0 {
@@ -31,12 +36,12 @@ func TestInitGobFileAuthBackend(t *testing.T) {
 }
 
 func TestGobReopen(t *testing.T) {
-	b, err := NewGobFileAuthBackend(file)
+	b, err := NewGobFileAuthBackend(gobfile)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
 	b.Close()
-	b, err = NewGobFileAuthBackend(file)
+	b, err = NewGobFileAuthBackend(gobfile)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/leveldbAuthBackend_test.go
+++ b/leveldbAuthBackend_test.go
@@ -11,14 +11,19 @@ var (
 
 func TestInitLeveldbAuthBackend(t *testing.T) {
 	// test if ErrMissingLeveldbBackend is thrown if no leveldb database exists
-	os.Remove(fileldb)
+	err := os.RemoveAll(fileldb)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
 	b, err := NewLeveldbAuthBackend(fileldb)
 	if err != ErrMissingLeveldbBackend {
 		t.Fatal(err.Error())
 	}
 
-	os.Mkdir(fileldb, 0700)
-	defer os.Remove(fileldb)
+	err = os.MkdirAll(fileldb, 0700)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
 	b, err = NewLeveldbAuthBackend(fileldb)
 	if err != nil {
 		t.Fatal(err.Error())
@@ -34,6 +39,7 @@ func TestInitLeveldbAuthBackend(t *testing.T) {
 }
 
 func TestLeveldbReopen(t *testing.T) {
+	defer os.RemoveAll(fileldb)
 	b, err := NewLeveldbAuthBackend(fileldb)
 	if err != nil {
 		t.Fatal(err.Error())


### PR DESCRIPTION
When using this package for go-ping-sites I ran into a need to update the properties of a user who is not the current session user.  For example the scenario in question is when an admin user needs to update another users's properties. Currently it will only update the in-session user.  In this modification it allows specifying the user by passing the username for the new behavior or passing as an empty string for the username which will keep the current behavior of getting from the session user.  Tests were also added for this case and the example was updated accordingly.

I also made a couple of minor changes to the gobflie and leveldb tests which were failing for me on Windows due to errors about files being used on subsequent tests.