### PR TITLE
Integrate Recent Change in User Update into Example

### DIFF
--- a/examples/server.go
+++ b/examples/server.go
@@ -6,9 +6,8 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/apexskier/httpauth"
 	"github.com/gorilla/mux"
-	"github.com/turnkey-commerce/httpauth"
-	"golang.org/x/crypto/bcrypt"
 )
 
 var (
@@ -37,12 +36,14 @@ func main() {
 	aaa, err = httpauth.NewAuthorizer(backend, []byte("cookie-encryption-key"), "user", roles)
 
 	// create a default user
-	hash, err := bcrypt.GenerateFromPassword([]byte("adminadmin"), bcrypt.DefaultCost)
+	username := "admin"
+	defaultUser := httpauth.UserData{Username: username, Role: "admin"}
+	err = backend.SaveUser(defaultUser)
 	if err != nil {
 		panic(err)
 	}
-	defaultUser := httpauth.UserData{Username: "admin", Email: "admin@localhost", Hash: hash, Role: "admin"}
-	err = backend.SaveUser(defaultUser)
+	// Update user with a password and email address
+	err = aaa.Update(nil, nil, username, "adminadmin", "admin@localhost.com")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This change is mainly to show in the example how to create a default user without directly accessing the bcrypt implementation, especially in case the bcrypt implementation changes in the future. In this case the API is used to create the user and then update the user password and email via the update feature.