### PR TITLE
Implement secure cookie 

### DIFF
--- a/auth_test.go
+++ b/auth_test.go
@@ -14,10 +14,11 @@ var (
 	file       = "auth_test.gob"
 	c          http.Client
 	authCookie http.Cookie
+	roles      map[string]Role
 )
 
 func init() {
-	roles := make(map[string]Role)
+	roles = make(map[string]Role)
 	roles["user"] = 40
 	roles["admin"] = 80
 	t, _ := time.Parse("Mon, 02 Jan 2006 15:04:05 MST", "Mon, 07 Apr 2014 21:47:54 UTC")
@@ -41,12 +42,20 @@ func TestNewAuthorizer(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	roles := make(map[string]Role)
-	roles["user"] = 40
-	roles["admin"] = 80
 	a, err = NewAuthorizer(b, []byte("testkey"), "user", roles)
 	if err != nil {
 		t.Fatal(err.Error())
+	}
+
+	if !a.cookiejar.Options.Secure {
+		t.Error("Cookie should be secure by default.")
+	}
+}
+
+func TestAllowInsecureCookie(t *testing.T) {
+	a.AllowInsecureCookie()
+	if a.cookiejar.Options.Secure {
+		t.Error("Cookie should be set to insecure.")
 	}
 }
 

--- a/examples/server.go
+++ b/examples/server.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/apexskier/httpauth"
 	"github.com/gorilla/mux"
-	"github.com/turnkey-commerce/httpauth"
 )
 
 var (
@@ -35,6 +35,8 @@ func main() {
 	roles["user"] = 30
 	roles["admin"] = 80
 	aaa, err = httpauth.NewAuthorizer(backend, []byte("cookie-encryption-key"), "user", roles)
+	// Don't use this function for production! Only used for testing when https is not available.
+	aaa.AllowInsecureCookie()
 
 	// create a default user
 	username := "admin"

--- a/examples/server.go
+++ b/examples/server.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"html/template"
 	"net/http"
-	"strings"
 	"os"
+	"strings"
 
-	"github.com/apexskier/httpauth"
 	"github.com/gorilla/mux"
+	"github.com/turnkey-commerce/httpauth"
 )
 
 var (


### PR DESCRIPTION
This PR resolves #33.  By default the secure cookie option is set when the NewAuthorizer() is called.  To turn it off a special function called AllowInsecureCookie() will need to be called to set it back to false.  Error messages are generated if the secure cookie is on and it the site is served over http.

The example is updated so that it will work by default on non-https sites but it has been appropriately commented to not do such in production.

The httpauth version should be incremented since it changes default behavior.